### PR TITLE
Implement QIODevice based send(). 

### DIFF
--- a/src/qmhdresponse.h
+++ b/src/qmhdresponse.h
@@ -6,9 +6,12 @@
 #include "qmhdglobal.h"
 
 class QFileDevice;
+class QIODevice;
 class QJsonDocument;
 
 class QMHDResponsePrivate;
+
+#define DEFAULT_DEVICE_BLOCK_SIZE 1024
 
 class QMHDResponse : public QObject
 {
@@ -25,6 +28,8 @@ class QMHDResponse : public QObject
     public:
         void send(const QByteArray& buffer);
         void send(const QJsonDocument& json);
+        void send(QIODevice* device,
+                  size_t blockSize=DEFAULT_DEVICE_BLOCK_SIZE);
         void send(int fileDescriptor, size_t fileSize);
         void send(int fileDescriptor, off_t fileOffset, size_t fileSize);
         void send();


### PR DESCRIPTION
This allows files or any other stream based on `QIODevice` to be used to contain the response. Large files etc are handled efficiently on all platforms by optionally specifying a `blockSize` when calling `send()`.
